### PR TITLE
Updates to fix floating point contour settings.

### DIFF
--- a/lib/formats.py
+++ b/lib/formats.py
@@ -1,0 +1,4 @@
+import numpy as np
+
+def float_format(num, precision=10, trim='-'):
+    return np.format_float_positional(num, precision=precision, trim=trim)

--- a/lib/plot.py
+++ b/lib/plot.py
@@ -7,6 +7,7 @@ import json
 import math
 import collections
 from string import *
+from formats import *
 
 import numpy as np
 
@@ -319,40 +320,65 @@ class Plot(object):
         self.handle  = PlotHandle(**self.request)
         self.defs    = self.handle.__dict__
 
-    def refine_clevs(self, clevs, nsub, type):
+# -----------------------------------------------------------------------------
 
-        clevs = [ float(clev) for clev in clevs.split() if clev != ' ' ]
 
+    def refine_clevs(self, clevs, nsub, type='linear'):
+        """
+        Refines contour levels by sub-dividing each interval into smaller
+        intervals.
+
+        This method refines the contour levels into a string of values
+        where each interval is sub-divided into equally spaced sub-intervals.
+
+        Parameters
+        ----------
+        clevs : string|string[]|float[]
+            String (blank delimited) or list of contour levels
+        nsub : int
+            Number of sub-divisions for each contour interval
+            E.g. [0,1] with nsub=10 will yield [0, 0.1, 0.2, ..., 1]
+        type : string
+            linear : default
+            log : logarithmic scaling
+
+        Returns
+        -------
+        levels : string
+            List-string of formatted contour levels (space delimited)
+
+        See Also
+        --------
+        float_format : method
+            Reformats floating point numbers into string values
+
+        """
         clevs_f = []
+        levels = []
+
+        # Set up interpolation parameters
+
         if type.upper() == 'LOG':
-
-            for index, clev in enumerate(clevs[0:-1]):
-
-                dclev = ( math.log(clevs[index+1]) - math.log(clev) ) / nsub
-                clevs_f.append(str(clev))
-
-                for ns in range(2,nsub+1):
-                    clev_f = math.log(clev) + (ns-1) * dclev
-                    clev_f = math.exp(clev_f)
-                    clev_f = "%3.2f"%clev_f
-                    clevs_f.append(clev_f)
-
-            clevs_f.append(str(clevs[-1]))
-
+            interpolate = np.logspace
+            options = dict(base=np.e, dtype=float)
+            clevs = [np.log(float(clev)) for clev in clevs.split() if clev != ' ']
         else:
+            interpolate = np.linspace
+            options = dict(dtype=float)
+            clevs = [float(clev) for clev in clevs.split() if clev != ' ']
 
-            for index, clev in enumerate(clevs[0:-1]):
+        # Interpolate to sub-divisions
 
-                dclev = ( clevs[index+1] - clev ) / nsub
-                clevs_f.append(str(clev))
+        for index, clev in enumerate(clevs[0:-1]):
+            levels = interpolate(clev, clevs[index+1], nsub+1, **options)
+            clevs_f += [float_format(level) for level in levels[0:-1]]
 
-                for ns in range(2,nsub+1):
-                    clev_f = clev + (ns-1) * dclev
-                    clevs_f.append(str(clev_f))
-
-            clevs_f.append(str(clevs[-1]))
+        clevs_f.append(float_format(levels[-1]))
 
         return ' '.join(clevs_f)
+
+# -----------------------------------------------------------------------------
+
 
     def refine_rgb(self, rgba, nsub):
 
@@ -508,27 +534,64 @@ class Plot(object):
 
         self.cmd(('set ccols '+' '.join(ccols) + ' ' + cpad).strip(), zorder=zorder)
 
-    def set_clevs(self, clevs, cmin, cmax, cint):
+# -----------------------------------------------------------------------------
 
-        if clevs: return clevs
-        if cmin is None: return 
-        if cmax is None: return
-        if cint is None: return
+
+    def set_clevs(self, clevs, cmin, cmax, cint):
+        """
+        Sets contour levels based on the specified min/max/increment.
+
+        This method expands the contour levels into a string of values
+        based on the range [cmin, cmax]. The values are formatted floats
+        using the assigned precision (see float_format method).
+
+        Parameters
+        ----------
+        clevs : string
+            List-string of contour levels (space delimited). If defined, these
+            levels are returned without modification.
+        cmin : string|float
+            Contour minimum value
+        cmax: string|float
+            Contour maximum value
+        cint: string|float
+            Contour interval (increment)
+
+        Returns
+        -------
+        levels : None|string
+            None: contour levels were unspecified
+            string: list-string of formatted contour levels (space delimited)
+
+        See Also
+        --------
+        float_format : method
+            Reformats floating point numbers into string values
+
+        """
+
+        # Return if contour level specification is incomplete
+        # or pre-specified.
+
+        if clevs:
+            return clevs
+        if None in (cmin, cmax, cint):
+            return
+
+        # Construct a list-string of values over the
+        # contour interval [cmin,cmax]
 
         vmin = float(cmin)
         vmax = float(cmax)
         vint = float(cint)
 
-        v    = vmin
         cout = []
-
-        assert vmin <= vmax and vint > 0, 'invalid range for cmin/cmax/cint'
-    
-        while v <= vmax:
-            cout.append(str(v))
+        for v in np.arange(vmin, vmax+vint/2.0, vint):
+            cout.append(float_format(v))
             v += vint
 
         return ' '.join(cout)
+
 
     def set_shade(self, clevs, rgba, nsub=1, type='linear', zorder=0, **kwargs):
 


### PR DESCRIPTION
This PR fixes the issue with contour levels and floating point precision. Two methods were rewritten: (1) refine_clevs() and (2) set_clevs. A new module named formats.py was also added. The main issue was the change in behavior for the string (str) method when converting to floating point notation. str(num) now yields variable precision and formatting and may inject scientific notation. Both (1) and (2) were re-written to use numpy.linspace and numpy.logspace. Formatting of floats into string format is now done using numpy.format_float_positional() . All fields in the SARP-West/chem2d configuration were plotted for testing. Off-line tests of the new methods were also performed. However, this branch cannot be tested on Discover due to other issues between the dataportal version of the codes and the discover version. The new codes were inserted here but we must carefully test on the dev server before moving to production.

Attached is an example of the corrected contour levels (uncorrected versus corrected).
![nasa gmao SARP-West chem2d G5FPFC cocl 0 sarpwest 2025-05-13T00_00_00 PT000H](https://github.com/user-attachments/assets/0902a234-5e81-4d1e-a3d4-cd3bdddd82f1)

![cocl](https://github.com/user-attachments/assets/f5ad39d4-36f6-4a11-b320-f70019f6753b)
